### PR TITLE
Add excludePattern CLI option to Perl script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The search functionality is implemented in [webidx.js](webidx.js) which uses [sq
 1. use [webidx.pl](webidx.pl) to generate the index:
 
 ```
-$ /path/to/webidx.pl -x index.html -x archives.html -o https://example.com -z . ./index.db
+$ /path/to/webidx.pl -x index.html -x archives.html --xP secret_files -o https://example.com -z . ./index.db
 ```
 
 You can run `webidx.pl --help` to see all the available command-line options.


### PR DESCRIPTION
This PR adds the option `--excludePattern` or `--xP` to the Perl script. This option allows the user to exclude entire directories or sets of files without having to specify each file. This is useful if you have a section of your site that you don't want index for some reason.